### PR TITLE
Make endpoints.yaml version not required to be 0.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36087,7 +36087,6 @@ const path = __nccwpck_require__(1017);
 
 // constants
 const ALLOWED_COMPONENT_YAML_VERSIONS = ["0.9", "1.0", "1.1"];
-const ALLOWED_ENDPOINT_YAML_VERSIONS = ["0.1"];
 const ALLOWED_TYPES = ["REST", "GraphQL", "GRPC", "TCP", "UDP", "WS"];
 const ALLOWED_NETWORK_VISIBILITIES = ["Public", "Project", "Organization"];
 const BASE_PATH_REQUIRED_TYPES = ["REST", "GraphQL", "WS"];
@@ -36334,7 +36333,7 @@ const componentYamlSchemaV1D0 = (srcDir) =>
 // endpointYamlSchema - Schema for endpoints.yaml
 const endpointYamlSchemaV0D1 = (srcDir) =>
   yup.object().shape({
-    version: yup.string().required().oneOf(ALLOWED_ENDPOINT_YAML_VERSIONS),
+    version: yup.string().required(),
     endpoints: endpointSchemaV0D1(srcDir).required().min(0),
   });
 

--- a/schemas.js
+++ b/schemas.js
@@ -5,7 +5,6 @@ const path = require("path");
 
 // constants
 const ALLOWED_COMPONENT_YAML_VERSIONS = ["0.9", "1.0", "1.1"];
-const ALLOWED_ENDPOINT_YAML_VERSIONS = ["0.1"];
 const ALLOWED_TYPES = ["REST", "GraphQL", "GRPC", "TCP", "UDP", "WS"];
 const ALLOWED_NETWORK_VISIBILITIES = ["Public", "Project", "Organization"];
 const BASE_PATH_REQUIRED_TYPES = ["REST", "GraphQL", "WS"];
@@ -252,7 +251,7 @@ const componentYamlSchemaV1D0 = (srcDir) =>
 // endpointYamlSchema - Schema for endpoints.yaml
 const endpointYamlSchemaV0D1 = (srcDir) =>
   yup.object().shape({
-    version: yup.string().required().oneOf(ALLOWED_ENDPOINT_YAML_VERSIONS),
+    version: yup.string().required(),
     endpoints: endpointSchemaV0D1(srcDir).required().min(0),
   });
 


### PR DESCRIPTION
$subject
This was done because the exact version number has no effect on the YAML, as there was only one YAML version.