### PR TITLE
Fix component yaml numbering issue

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36325,7 +36325,10 @@ const componentYamlSchemaV1D0 = (srcDir) =>
     schemaVersion: yup
       .number()
       .required()
-      .oneOf(ALLOWED_COMPONENT_YAML_VERSIONS),
+      .oneOf(
+        ALLOWED_COMPONENT_YAML_VERSIONS,
+        "schemaVersion must be one of the following values: 0.9, 1.0, 1.1"
+      ),
     endpoints: endpointSchemaV0D2(srcDir),
     dependencies: dependencySchemaV0D1,
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -36086,7 +36086,7 @@ const fs = __nccwpck_require__(7147);
 const path = __nccwpck_require__(1017);
 
 // constants
-const ALLOWED_COMPONENT_YAML_VERSIONS = ["0.9", "1.0", "1.1"];
+const ALLOWED_COMPONENT_YAML_VERSIONS = [0.9, 1.0, 1.1];
 const ALLOWED_TYPES = ["REST", "GraphQL", "GRPC", "TCP", "UDP", "WS"];
 const ALLOWED_NETWORK_VISIBILITIES = ["Public", "Project", "Organization"];
 const BASE_PATH_REQUIRED_TYPES = ["REST", "GraphQL", "WS"];
@@ -36323,7 +36323,7 @@ const specSchema = (srcDir) =>
 const componentYamlSchemaV1D0 = (srcDir) =>
   yup.object().shape({
     schemaVersion: yup
-      .string()
+      .number()
       .required()
       .oneOf(ALLOWED_COMPONENT_YAML_VERSIONS),
     endpoints: endpointSchemaV0D2(srcDir),

--- a/schemas.js
+++ b/schemas.js
@@ -243,7 +243,10 @@ const componentYamlSchemaV1D0 = (srcDir) =>
     schemaVersion: yup
       .number()
       .required()
-      .oneOf(ALLOWED_COMPONENT_YAML_VERSIONS),
+      .oneOf(
+        ALLOWED_COMPONENT_YAML_VERSIONS,
+        "schemaVersion must be one of the following values: 0.9, 1.0, 1.1"
+      ),
     endpoints: endpointSchemaV0D2(srcDir),
     dependencies: dependencySchemaV0D1,
   });

--- a/schemas.js
+++ b/schemas.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 
 // constants
-const ALLOWED_COMPONENT_YAML_VERSIONS = ["0.9", "1.0", "1.1"];
+const ALLOWED_COMPONENT_YAML_VERSIONS = [0.9, 1.0, 1.1];
 const ALLOWED_TYPES = ["REST", "GraphQL", "GRPC", "TCP", "UDP", "WS"];
 const ALLOWED_NETWORK_VISIBILITIES = ["Public", "Project", "Organization"];
 const BASE_PATH_REQUIRED_TYPES = ["REST", "GraphQL", "WS"];
@@ -241,7 +241,7 @@ const specSchema = (srcDir) =>
 const componentYamlSchemaV1D0 = (srcDir) =>
   yup.object().shape({
     schemaVersion: yup
-      .string()
+      .number()
       .required()
       .oneOf(ALLOWED_COMPONENT_YAML_VERSIONS),
     endpoints: endpointSchemaV0D2(srcDir),


### PR DESCRIPTION
In the component.yaml file, when schemaVersion is defined as a string, it will not work for version 1.0 because JavaScript will convert this string to 1, not 1.0.