### PR TITLE
Fix schema version match fails when value is a string

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38382,21 +38382,22 @@ function constructValidationErrorMessage(err, fileType) {
 }
 
 async function validateComponentYaml(sourceRootDir, schemaVersion) {
-  switch (schemaVersion) {
+  parsedSchemaVersion = Number(schemaVersion);
+  switch (parsedSchemaVersion) {
     case 1.0:
-      await componentYamlSchemaV1D0(sourceRootDir).validate(
-        srcConfigYamlFile,
-        { abortEarly: false }
-      );
+      await componentYamlSchemaV1D0(sourceRootDir).validate(srcConfigYamlFile, {
+        abortEarly: false,
+      });
       break;
     case 1.1:
-      await componentYamlSchemaV1D1(sourceRootDir).validate(
-        srcConfigYamlFile,
-        { abortEarly: false }
-      );
+      await componentYamlSchemaV1D1(sourceRootDir).validate(srcConfigYamlFile, {
+        abortEarly: false,
+      });
       break;
     default:
-      throw new Error(`SchemaVersion must be one of the following values: 1.0, 1.1`);
+      throw new Error(
+        `SchemaVersion must be one of the following values: 1.0, 1.1`
+      );
   }
 }
 
@@ -38405,7 +38406,7 @@ async function validateSourceConfigFile(sourceRootDir, fileType) {
     switch (fileType) {
       case sourceConfigFileTypes.COMPONENT_YAML:
         const schemaVersion = srcConfigYamlFile.schemaVersion;
-        await validateComponentYaml(sourceRootDir, schemaVersion)
+        await validateComponentYaml(sourceRootDir, schemaVersion);
         break;
       case sourceConfigFileTypes.COMPONENT_CONFIG_YAML:
         await componentConfigYamlSchemaV1beta1(sourceRootDir).validate(

--- a/index.js
+++ b/index.js
@@ -63,21 +63,22 @@ function constructValidationErrorMessage(err, fileType) {
 }
 
 async function validateComponentYaml(sourceRootDir, schemaVersion) {
-  switch (schemaVersion) {
+  parsedSchemaVersion = Number(schemaVersion);
+  switch (parsedSchemaVersion) {
     case 1.0:
-      await componentYamlSchemaV1D0(sourceRootDir).validate(
-        srcConfigYamlFile,
-        { abortEarly: false }
-      );
+      await componentYamlSchemaV1D0(sourceRootDir).validate(srcConfigYamlFile, {
+        abortEarly: false,
+      });
       break;
     case 1.1:
-      await componentYamlSchemaV1D1(sourceRootDir).validate(
-        srcConfigYamlFile,
-        { abortEarly: false }
-      );
+      await componentYamlSchemaV1D1(sourceRootDir).validate(srcConfigYamlFile, {
+        abortEarly: false,
+      });
       break;
     default:
-      throw new Error(`SchemaVersion must be one of the following values: 1.0, 1.1`);
+      throw new Error(
+        `SchemaVersion must be one of the following values: 1.0, 1.1`
+      );
   }
 }
 
@@ -86,7 +87,7 @@ async function validateSourceConfigFile(sourceRootDir, fileType) {
     switch (fileType) {
       case sourceConfigFileTypes.COMPONENT_YAML:
         const schemaVersion = srcConfigYamlFile.schemaVersion;
-        await validateComponentYaml(sourceRootDir, schemaVersion)
+        await validateComponentYaml(sourceRootDir, schemaVersion);
         break;
       case sourceConfigFileTypes.COMPONENT_CONFIG_YAML:
         await componentConfigYamlSchemaV1beta1(sourceRootDir).validate(

--- a/test/component-yaml-samples.js
+++ b/test/component-yaml-samples.js
@@ -1,4 +1,4 @@
-const validComponentYaml = `schemaVersion: 1.0
+const validComponentYaml = `schemaVersion: "1.0"
 endpoints:
   - name: greeter-sample
     displayName: Go Greeter Sample


### PR DESCRIPTION
Related: https://github.com/choreo-templates/choreo-source-config-validator/pull/22