### PR TITLE
Add validation for storage service references and update test cases

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36256,6 +36256,10 @@ yup.addMethod(yup.string, "validateResourceRef", function () {
       const dbSvcRefNameRegex = new RegExp(
         "^database:(([a-zA-Z0-9_-]+)\/)?([a-zA-Z0-9_-]+)$"
       );
+      const storageSvcRefNameRegex = new RegExp(
+        "^storage:([a-zA-Z0-9\\s_.-]+)$"
+      );
+
       if (value.startsWith("service:")) {
         return (
           svcRefNameRegex.test(value) ||
@@ -36285,6 +36289,17 @@ yup.addMethod(yup.string, "validateResourceRef", function () {
           )
         );
       }
+      if (value.startsWith("storage:")) {
+        return (
+          storageSvcRefNameRegex.test(value) ||
+          new yup.ValidationError(
+            `${testCtx.path} has an invalid service identifier. ` +
+            `Use the format storage:<service_name>, ` +
+            `allowing only alphanumeric characters, spaces, periods (.), underscores (_), and hyphens (-) after storage:.`
+          )
+        );
+      }
+
       return (
         // since "service:" is optional, we need to validate again with a generic error
         svcRefNameRegex.test(value) ||

--- a/schemas.js
+++ b/schemas.js
@@ -174,6 +174,10 @@ yup.addMethod(yup.string, "validateResourceRef", function () {
       const dbSvcRefNameRegex = new RegExp(
         "^database:(([a-zA-Z0-9_-]+)\/)?([a-zA-Z0-9_-]+)$"
       );
+      const storageSvcRefNameRegex = new RegExp(
+        "^storage:([a-zA-Z0-9\\s_.-]+)$"
+      );
+
       if (value.startsWith("service:")) {
         return (
           svcRefNameRegex.test(value) ||
@@ -203,6 +207,17 @@ yup.addMethod(yup.string, "validateResourceRef", function () {
           )
         );
       }
+      if (value.startsWith("storage:")) {
+        return (
+          storageSvcRefNameRegex.test(value) ||
+          new yup.ValidationError(
+            `${testCtx.path} has an invalid service identifier. ` +
+              `Use the format storage:<service_name>, ` +
+              `allowing only alphanumeric characters, spaces, periods (.), underscores (_), and hyphens (-) after storage:.`
+          )
+        );
+      }
+
       return (
         // since "service:" is optional, we need to validate again with a generic error
         svcRefNameRegex.test(value) ||

--- a/test/component-yaml-samples.js
+++ b/test/component-yaml-samples.js
@@ -161,7 +161,7 @@ endpoints:
       basePath: /greeting-service
       port: 9090
     type: REST`;
-  
+
 
 const validateProjectVisibilityOnlyType = `schemaVersion: 1.0
 endpoints:
@@ -541,7 +541,13 @@ dependencies:
       - name: valid_connection_name1
         resourceRef: database:/mySqlDbServer/hotelDb
       - name: valid_connection_name1
-        resourceRef: THIRDPARTY:mySqlDbServer/hotelDb/invalid`;
+        resourceRef: THIRDPARTY:mySqlDbServer/hotelDb/invalid
+      - name: valid_connection_name1
+        resourceRef: storage:myStorageService1
+      - name: invalid_connection_name1
+        resourceRef: storage:myStorageService!
+      - name: valid_connection_name1
+        resourceRef: storage:my-storage.service_2 space`;
 
 const validateConfigurations = `schemaVersion: 1.1
 configuration:

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -380,6 +380,7 @@ describe("dependencySchemaV0D2 schema tests", () => {
       "dependencies.connectionReferences[19].resourceRef has an invalid service identifier. Use the format database:[<serverName>/]<databaseName> where optional fields are in brackets, allowing only alphanumeric characters, underscores (_), hyphens (-), and slashes (/) after database:.",
       "dependencies.connectionReferences[20].resourceRef has an invalid service identifier. Use the format database:[<serverName>/]<databaseName> where optional fields are in brackets, allowing only alphanumeric characters, underscores (_), hyphens (-), and slashes (/) after database:.",
       "dependencies.connectionReferences[21].resourceRef has an invalid service identifier. For services, use [service:][/<project-handle>/]<component-handle>/<major-version>[/<endpoint-handle>][/<network-visibility>]. For databases, use database:[<serverName>/]<databaseName>. For third-party services, use thirdparty:<service_name>/<version>. Optional fields are specified in brackets.",
+      "dependencies.connectionReferences[23].resourceRef has an invalid service identifier. Use the format storage:<service_name>, allowing only alphanumeric characters, spaces, periods (.), underscores (_), and hyphens (-) after storage:.",
     ];
     await expectValidationErrors(
       COMPONENT_YAML,


### PR DESCRIPTION
Allows connection references to have connections to storage resources like the example given below. This pull request resolves https://github.com/wso2-enterprise/choreo/issues/38959

```yaml
dependencies:
  connectionReferences:
    - name: Con1
      resourceRef: storage:Store1
```